### PR TITLE
Adding patch for proper formatting code url with underscores

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -63,7 +63,7 @@
 
       \ifdefempty{\codeURL}{}
       {Code is available at
-      \href{\codeURL}{\codeURL}\ifdefempty{\codeDOI}{.}{ -- DOI \doi{\codeDOI}.}}
+      \href{\codeURL}{\detokenize\expandafter{\codeURL}}\ifdefempty{\codeDOI}{.}{ -- DOI \doi{\codeDOI}.}}
 
       \ifdefempty{\dataURL}{}
       {Data is available at


### PR DESCRIPTION
When `\codeDOI` contains url with underscores, the formatting of the resulting latex is messed up because latex treats underscore as a starting token for math mode. Using the following escape sequencing helps in proper display: `\detokenize\expandafter{ .. }`