### PR TITLE
fix minor UTF8 bug in yaml-to-latex.py

### DIFF
--- a/yaml-to-latex.py
+++ b/yaml-to-latex.py
@@ -66,8 +66,12 @@ def generate_latex_metadata(filename, article):
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
+    import locale
     import argparse
     from article import Article
+
+    # Set to a UTF-8 locale - any non-ascii characters in the metadata in metadata.yaml should be in UTF-8
+    locale.setlocale(locale.LC_ALL,'en_US.UTF-8')
 
     parser = argparse.ArgumentParser(description='YAML to latex converter.')
     parser.add_argument('--input', '-i', dest='filename_in', action='store',


### PR DESCRIPTION
If the user enters non-ascii metadata in metadata.yaml in UTF8,
e.g.
    name:    Institute of Ąćçęńted Letterś in Półiśh and Freńćh
    address: Żyźszczyń
but in the terminal has a non-UTF8 locale setting such as LANG=C
or LANG=fr_FR.ISO-8859-1, then yaml-to-latex.py will yield an
error and 'make' will fail.

This commit sets the locale, within the python process, to en-US.UTF-8.
It should fix Issue https://github.com/ReScience/template/issues/4

Further improvements could be to check whether the existing locale
is UTF-8 and to warn the user if it is not.