### PR TITLE
agreement with plural

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -62,7 +62,7 @@
       Correspondence should be addressed to
       \contactNAME~(\href{mailto:\contactEMAIL}{\contactEMAIL})
   
-      The authors have declared that no competing interests exists.
+      The authors have declared that no competing interests exist.
 
       \ifdefempty{\codeURL}{}
       {Code is available at


### PR DESCRIPTION
"No competing interest exists" would also be possible, but seems less commonly used according to Google.