### PR TITLE
MAINT: add explicit yaml.Loader

### DIFF
--- a/article.py
+++ b/article.py
@@ -168,7 +168,7 @@ class Article:
             
         
     def parse(self, data):
-        document = yaml.load(data)
+        document = yaml.load(data, Loader=yaml.SafeLoader)
 
         self.title = document.get("title", "")
         self.abstract = document.get("abstract","") or ""


### PR DESCRIPTION
To silence the DeprecationWarning (observed with pyyaml 5.3.1)

See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
for discussion

Prompted by https://github.com/ReScience/template/issues/10#issuecomment-622423817