### PR TITLE
Add optional author suffix

### DIFF
--- a/article.py
+++ b/article.py
@@ -4,12 +4,15 @@
 import yaml
 
 class Contributor:
-    def __init__(self, role, name, orcid="", email="", affiliations=[]):
+    def __init__(self, role, name, suffix="", orcid="", email="", affiliations=[]):
         self.role = role
-        self.name = name
-        self.fullname = name
+        self.name = " ".join([name, suffix]) if suffix else name
+        self.fullname = " ".join([name, suffix]) if suffix else name
+        # lastname = self.get_lastname(name)
+        # self.lastname = " ".join([lastname, suffix]) if suffix else lastname
         self.lastname = self.get_lastname(name)
-        self.abbrvname = self.get_abbrvname(name)
+        abbrvname = self.get_abbrvname(name)
+        self.abbrvname = " ".join([abbrvname, suffix]) if suffix else abbrvname
         self.orcid = orcid
         self.email = email
         self.affiliations = affiliations
@@ -189,6 +192,7 @@ class Article:
         for item in document["authors"]:
             role = "author"
             name = item["name"] or ""
+            suffix = item.get("suffix", "") or ""
             orcid = item.get("orcid","") or ""
             email = item.get("email","") or ""
             if item["affiliations"] is not None:
@@ -196,15 +200,15 @@ class Article:
                     affiliations = item["affiliations"].split(",")
                     if "*" in affiliations:
                         affiliations.remove("*")
-                        author = Contributor(role, name, orcid, email, affiliations)
+                        author = Contributor(role, name, suffix, orcid, email, affiliations)
                         self.add_contributor(author)
                         self.contact = author
                     else:
-                        author = Contributor(role, name, orcid, email, affiliations)
+                        author = Contributor(role, name, suffix, orcid, email, affiliations)
                         self.add_contributor(author)
                 else:
                     affiliations = list(str(item["affiliations"]))
-                    author = Contributor(role, name, orcid, email, affiliations)
+                    author = Contributor(role, name, suffix, orcid, email, affiliations)
                     self.add_contributor(author)
                 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,11 +11,13 @@ title: "ReScience (R)evolution"
 # Affiliation "*" means contact author (required even for single-authored papers)
 authors:
   - name: Konrad Hinsen
+    suffix: # Optional author name suffix
     orcid: 0000-0003-0330-9428
     email: konrad.hinsen@cnrs.fr
     affiliations: 1,2
     
   - name: Nicolas P. Rougier
+    suffix:
     orcid: 0000-0002-6972-589X
     email: Nicolas.Rougier@inria.fr
     affiliations: 3,4,5,*      # * is for contact author


### PR DESCRIPTION
This pull request would add an optional author suffix field in `metadata.yaml` and account for this change in `article.py`. This addresses issue #29 .

The current version adds the suffix to the name as it appears in the author list  (`self.name` and `self.fullname`) and the copyright statement (`self.abbrvname`). However, the name in the footnote shows lastname without suffix (`self.lastname`).

I have included commented-out code which would add the suffix to the footnote as well (`article.py` lines 11 & 12). This will be up to the discretion of the editors which version could be pulled into the main repo should they decide to allow suffixes. Before merging, we should either:

- Delete lines 11 & 12 of `article.py`, or
- Delete line 13 and uncomment lines 11 & 12

I have tried the current code and it appears fully functional. I did not commit a modified `metadata.yaml` to add suffixes to any names, but I did try it out locally.