### PR TITLE
Add support for suffixes (simpler method)

### DIFF
--- a/article.py
+++ b/article.py
@@ -3,6 +3,8 @@
 
 import yaml
 
+SUFFIXES = ["II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+
 class Contributor:
     def __init__(self, role, name, orcid="", email="", affiliations=[]):
         self.role = role
@@ -23,6 +25,9 @@ class Contributor:
         else:
             lastname = name.split(" ")[-1]
             firstnames = name.split(" ")[:-1]
+            if lastname in SUFFIXES:
+                lastname = " ".join(name.split(" ")[-2:])
+                firstnames = name.split(" ")[:-2]
         abbrvname = ""
         for firstname in firstnames:
             if "-" in firstname:
@@ -43,6 +48,8 @@ class Contributor:
         # Nicolas P. Rougier
         else:
             lastname = name.split(" ")[-1]
+            if lastname in SUFFIXES:
+                lastname = " ".join(name.split(" ")[-2:])
             firstname = name.split(" ")[:-1]
         return lastname
     


### PR DESCRIPTION
This pull request addresses issue #29 using a simpler method, and with fewer changes, than pull request #30. In this version, `metadata.yaml` is unchanged. When splitting the last name from the name string, it is compared against a list of suffixes ("II" - "X") for membership. If the "last name" is actually a suffix, it pulls out the string before it as well.

While this method is simpler, it will be incorrect if an author's last name matches one of the strings in the suffix list.