### PR TITLE
Add comment to metadata.yaml about author suffix

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,6 +9,7 @@ title: "ReScience (R)evolution"
 
 # List of authors with name, orcid number, email and affiliation
 # Affiliation "*" means contact author (required even for single-authored papers)
+# To include author suffix format name as Last Suffix, First M.I. (e.g. Schackart III, Kenneth E.)
 authors:
   - name: Konrad Hinsen
     orcid: 0000-0003-0330-9428


### PR DESCRIPTION
I have added a brief comment to the metadata.yaml instructing authors how to include a suffix with their name. This is in response to #29.

The main drawback is that the author name under the title in the PDF maintains the formatting as "Last Suffix, First M.I.". One cannot have it formatted as "First M.I. Last Suffix" in the PDF.

Also, I used my name as an example in the comment in metadata.yaml. I am happy to change it to another name if the maintainers wish.